### PR TITLE
Guard against missing cloud base layer

### DIFF
--- a/lib/forecast.py
+++ b/lib/forecast.py
@@ -24,7 +24,7 @@ def findMinimumCeiling(forecast):
         coverage = layer['sky_cover']
         if coverage not in [BROKEN, OVERCAST]:
             continue
-        base = int(layer['cloud_base_ft_agl'])
+        base = int(layer['cloud_base_ft_agl']) if 'cloud_base_ft_agl' in layer else 0
         if (ceiling is None) or (base < ceiling):
             ceiling = base
     return ceiling


### PR DESCRIPTION
Sometimes the sky condition is missing a `cloud_base_ft_agl`, which was throwing an error. Just need to guard against it.